### PR TITLE
feat(project-cleanup): Remove .xasm files from template loading

### DIFF
--- a/src/main/commandlib/command/util/Util.java
+++ b/src/main/commandlib/command/util/Util.java
@@ -18,8 +18,8 @@ public class Util {
   }
 
   public static String loadTemplateFile(String templateFile) {
-    String[] types = { "asm", "xasm" };
-    LoadFile file = new LoadFile(templateFile, types, "../../lib/command-library");
+    String type = "asm";
+    LoadFile file = new LoadFile(templateFile, type, "../../lib/command-library");
     File template = file.getFile();
 
     String parsedOutput = "";


### PR DESCRIPTION
Template files were originally intended to have their own template type. This feature became stale when I realied it wasn't necessary.